### PR TITLE
feat: add roll command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 This is a bot that I created to to mess around with my friends in our Discord server. Robles-Bot can do anything from play music from a YouTube link in your chat channel, to calling a phone and talking with text to speech. I will be adding more commands once I have more free time, but feel free to branch and contribute your own as well!
 
+## Commands
+
+- /ping - Replies with Pong!
+- /roll - Rolls a dice with optional sides and count.
+
 ## Installation
 
 ```

--- a/commands/fun/roll.js
+++ b/commands/fun/roll.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('roll')
+		.setDescription('Rolls a dice with optional sides and count.')
+		.addIntegerOption(option =>
+			option.setName('sides')
+				.setDescription('Number of sides per die')
+				.setRequired(false))
+		.addIntegerOption(option =>
+			option.setName('count')
+				.setDescription('Number of dice to roll')
+				.setRequired(false)),
+	async execute(interaction) {
+		const sides = interaction.options.getInteger('sides') ?? 6;
+		const count = interaction.options.getInteger('count') ?? 1;
+		if (sides <= 0 || count <= 0) {
+			return interaction.reply({ content: 'Sides and count must be positive integers.', ephemeral: true });
+		}
+		const rolls = Array.from({ length: count }, () => Math.floor(Math.random() * sides) + 1);
+		await interaction.reply(`You rolled: ${rolls.join(', ')}`);
+	},
+};


### PR DESCRIPTION
## Summary
- add `/roll` command to throw dice with configurable sides and count
- document available slash commands

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68926a914ccc8322a8188a8c5306194c