### PR TITLE
Handle non-directory entries in command loader

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -10,7 +10,10 @@ const token = process.env.DISCORD_TOKEN;
 const commands = [];
 // Grab all the command files from the commands directory you created earlier
 const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
+const commandFolders = fs
+  .readdirSync(foldersPath, {withFileTypes: true})
+  .filter(dirent => dirent.isDirectory())
+  .map(dirent => dirent.name);
 
 for (const folder of commandFolders) {
   // Grab all the command files from the commands directory you created earlier

--- a/server.js
+++ b/server.js
@@ -8,7 +8,10 @@ const client = new Client({intents: [GatewayIntentBits.Guilds]});
 client.commands = new Collection();
 
 const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
+const commandFolders = fs
+  .readdirSync(foldersPath, {withFileTypes: true})
+  .filter(dirent => dirent.isDirectory())
+  .map(dirent => dirent.name);
 
 for (const folder of commandFolders) {
   const commandsPath = path.join(foldersPath, folder);


### PR DESCRIPTION
## Summary
- Avoid loading non-directories as command folders in server
- Apply same directory filtering for deploy-commands script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68926a6ac778832288652e401b754b05